### PR TITLE
update packages: rl, brew

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,10 +36,8 @@
           <div class="card">
               <h3>Packages</h3>
                 <ul>
-                     <li><a class="kernel-link" data-modal-text="Core toolkit for macOS and Apple platforms." href="https://github.com/harpertoken/harper/pkgs/container/harper%2Fharper">harper</a></li>
-                     <li><a class="kernel-link" data-modal-text="AI-powered awareness and monitoring tool." href="https://github.com/orgs/harpertoken/packages/container/package/llamaware">llamaware</a></li>
-                     <li><a class="kernel-link" data-modal-text="Cross-platform path and directory utilities." href="https://github.com/orgs/harpertoken/packages/npm/package/cross-platform-path-utils">cross-platform-path-utils</a></li>
-                     <li><a class="kernel-link" data-modal-text="Retrieval-Augmented Generation for AI interactions." href="https://github.com/orgs/harpertoken/packages/container/package/rag">rag</a></li>
+                     <li><a class="kernel-link" data-modal-text="Reinforcement learning toolkit for macOS and Apple platforms." href="https://github.com/harpertoken/rl/pkgs/container/rl">rl</a></li>
+                     <li><a class="kernel-link" data-modal-text="Homebrew formula and package definitions." href="https://github.com/harpertoken/brew/pkgs/container/brew">brew</a></li>
                 </ul>
           </div>
         <div class="card">


### PR DESCRIPTION
We have updated the packages section to reflect our current focus. The previous packages (harper, llamaware, cross-platform-path-utils, rag) have been replaced with rl and brew.

This change clarifies the distinction between what constitutes a package in our ecosystem. A package is a distributable, installable unit that users can directly consume - whether through Docker containers, Homebrew, or other package managers. This helps visitors better understand what they can install and use directly versus what they may find in our repositories.